### PR TITLE
feat: make assignees an array of strings in create_action schema and handler

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -110,14 +110,14 @@ server.tool(
   {
     title: z.string(),
     projectId: z.string().optional(),
-    assigneeId: z.string().optional(),
+    assignees: z.array(z.string()).optional(),
     description: z.string().optional(),
   },
   async (
     args: {
       title: string;
       projectId?: string;
-      assigneeId?: string;
+      assignees?: string[];
       description?: string;
     },
     extra: Extra,


### PR DESCRIPTION
This PR updates the create_action tool to accept assignees as an array of strings, both in the zod schema and the handler argument type.